### PR TITLE
Config three

### DIFF
--- a/build_tools/config_three.rb
+++ b/build_tools/config_three.rb
@@ -1,0 +1,104 @@
+require_relative "johnny_five"
+require 'forwardable'
+
+class JohnnyThree
+  extend Forwardable
+  attr_accessor :johnny, :branch, :component, :pr
+  def initialize
+    @johnny = JohnnyFive.new
+    @branch = ENV["TRAVIS_BRANCH"]
+    @component = ENV["TEST_SUITE"] || ENV["GEM"]
+    self.range = ENV["TRAVIS_COMMIT_RANGE"]
+    @pr = ENV["TRAVIS_PULL_REQUEST"] != "false"
+  end
+
+  def_delegators :johnny, :rules, :files
+
+  def setup
+    matrix = johnny.translator
+    matrix.suite %w(controllers models) do |cfg|
+      cfg.file "Gemfile"
+      cfg.file "config/**/*"
+      cfg.trigger "one"
+    end
+
+    matrix.suite "models" do |cfg|
+      cfg.file "app/models/**/*"
+      cfg.file "db/**/*.rb"
+      cfg.file "test/fixtures/**/*"
+      cfg.test "test/models/**/*_test.rb"
+    end
+
+    matrix.suite "controllers" do |cfg|
+      cfg.file "app/controllers/**/*.rb"
+      cfg.file "app/views/**/*"
+      cfg.file "app/helpers/**/*"
+      cfg.trigger "models"
+      cfg.test "test/{controllers,views}/**/*_test.rb"
+      cfg.test "test/helpers/**/*_test.rb"
+    end
+
+    matrix.suite "ui" do |cfg|
+      cfg.file "app/assets/**/*"
+      cfg.file "config/**/*"
+      cfg.file "public/**/*"
+      cfg.file "vendor/**/*"
+      cfg.trigger "controller"
+      cfg.test "test/integration/**/*_test.rb"
+    end
+
+    matrix.suite "j5" do |cfg|
+      cfg.file "build_tools/**/*"
+    end
+
+    matrix.suite "one" do |cfg|
+      # would like to say except test
+      cfg.file "gems/one/**/*"
+      cfg.test "gems/one/test/**/*"
+    end
+
+    matrix.suite :none do |cfg|
+      cfg.file "README.md"
+      cfg.file "Rakefile"
+
+      cfg.file "bin/**/*"
+      cfg.file "log/**/*"
+      cfg.file "lib/tasks/**/*"
+      cfg.file "tmp/**/*"
+    end
+
+    matrix.suite :all do |cfg|
+      cfg.test "test/test_helper.rb"
+    end
+    self
+  end
+
+  # main logic to determine what to do
+  def deduce
+    if pr
+      #targets, regexps, regexp = johnny.rules.resolve(component)
+      # list("DETECT:") { targets }
+      # list("REGEX:") { regexps }
+      regexp = johnny.rules[component]
+      triggered_file = johnny.files.detect { |fn| regexp.match(fn) }
+      if triggered_file
+        puts "building PR for #{component} (triggered by #{triggered_file}"
+      else
+        puts "skipping PR for unchanged: #{component}"
+        exit(1)
+      end
+    else
+      # build everything on master
+      if branch && %w(master).include?(branch)
+        puts "building branch: #{branch}"
+      else
+        puts "skipping branch: #{branch || "none specified"}"
+        exit(1)
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  JohnnyThree.new.setup.deduce
+end

--- a/build_tools/johnny_five.rb
+++ b/build_tools/johnny_five.rb
@@ -56,16 +56,16 @@ class JohnnyFive
     # @return [Hash<String,Array<String>] target and targets that will trigger a build
     attr_accessor :shallow_dependencies
 
-    def add_rule(name, value)
-      add_all(shallow_rules, name, glob2regex(value))
+    def add_rule(name, glob)
+      add_all(shallow_rules, name, glob2regex(glob))
     end
 
-    def add_shallow_rule(name, value)
-      add_all(non_dependent_rules, name, glob2regex(value))
+    def add_shallow_rule(name, glob)
+      add_all(non_dependent_rules, name, glob2regex(glob))
     end
 
-    def add_dependency(name, value)
-      add_all(shallow_dependencies, name, value)
+    def add_dependency(name, target)
+      add_all(shallow_dependencies, name, target)
     end
 
     # @param targets [Array<String>] list of targets. (please expand with `dependencies` first)
@@ -101,7 +101,7 @@ class JohnnyFive
     end
     alias_method :[], :regexp
 
-    # @return [Regexp] rule to match every file (for sanity checks)
+    # @return [Regexp] rule to match every file that is covered by a rule (for sanity checks)
     def every
       Regexp.union((shallow_rules.values.flatten + non_dependent_rules.values.flatten).uniq)
     end
@@ -277,7 +277,7 @@ class JohnnyFive
     def_delegators :files, :range=
 
     def suite(name)
-      @suite = name.kind_of?(Array) ? name : [name]
+      @suite = name
       yield self
     end
 


### PR DESCRIPTION
/cc @matthewd reduced this further

feels like under 250 isnt buying much.
I put in a "fold" where I feel the line count max (~150) belongs. and there are still lines above there that also could go.
- hard coding env vars and removing argv bought 60 lines. but hard coded env feels messy.
- custom branch vs pr logic reduced many vars, but makes logic confusing when mixed with config.
- even harder to test w/ env vars (tests already poor)
- I like the dsl. it is small but still feels too big. could move directly into rules class. but feels dirty
- feedback around resolution of rules and dependencies adds 25(?) lines to rules. I use a lot for debug, so is needed. but ooh so verbose. maybe adding a debug method or something?
- `add_rule` stuff is too verbose. but the way the maps work feels very implementation centric. was thinking of subclassing the hashes and adding a custom []= method. avoided this though.
